### PR TITLE
[feat] jwt 환경변수 세팅 수정

### DIFF
--- a/IMFast/app/api/auth.py
+++ b/IMFast/app/api/auth.py
@@ -25,15 +25,15 @@ async def login(
             "message": "Login Success",
             "access_token": create_access_token(
                 username,
-                expires_delta=settings.access_token_expire,
-                secret_key=settings.secret_key,
-                algorithm=settings.algorithm
+                expires_delta=settings.jwt_access_expires,
+                secret_key=settings.jwt_secret_key,
+                algorithm=settings.jwt_algorithm
             ),
             "refresh_token": create_refresh_token(
                 username,
-                expires_delta=settings.refresh_token_expire,
-                secret_key=settings.secret_key,
-                algorithm=settings.algorithm
+                expires_delta=settings.jwt_refresh_expires,
+                secret_key=settings.jwt_secret_key,
+                algorithm=settings.jwt_algorithm
             )
         })
     else:
@@ -56,15 +56,15 @@ async def refresh(
         "message": "Refresh Success",
         "access_token": create_access_token(
             identity,
-            expires_delta=settings.access_token_expire,
-            secret_key=settings.secret_key,
-            algorithm=settings.algorithm
+            expires_delta=settings.jwt_access_expires,
+            secret_key=settings.jwt_secret_key,
+            algorithm=settings.jwt_algorithm
         ),
         "refresh_token": create_refresh_token(
             identity,
-            expires_delta=settings.refresh_token_expire,
-            secret_key=settings.secret_key,
-            algorithm=settings.algorithm
+            expires_delta=settings.jwt_refresh_expires,
+            secret_key=settings.jwt_secret_key,
+            algorithm=settings.jwt_algorithm
         )
     })
 

--- a/IMFast/app/depends/jwt.py
+++ b/IMFast/app/depends/jwt.py
@@ -22,7 +22,7 @@ async def access_token(
         raise JWTError("Bearer Token is required")
     if not is_access(
         token,
-        secret_key=settings.secret_key,
+        secret_key=settings.jwt_secret_key,
         algorithm=settings.algorithm
     ):
         raise JWTError("Token is access token")
@@ -46,8 +46,8 @@ async def refresh_token(
         raise JWTError("Token is not refresh token")
     identity = get_identity(
         token,
-        secret_key=settings.secret_key,
-        algorithm=settings.algorithm
+        secret_key=settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm
     )
     return identity
 

--- a/IMFast/app/depends/jwt.py
+++ b/IMFast/app/depends/jwt.py
@@ -42,7 +42,11 @@ async def refresh_token(
         token = token[7:]
     else:
         raise JWTError("Bearer Token is required")
-    if not is_refresh(token):
+    if not is_refresh(
+        token=token,
+        secret_key=settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm
+    ):
         raise JWTError("Token is not refresh token")
     identity = get_identity(
         token,

--- a/IMFast/settings.py
+++ b/IMFast/settings.py
@@ -22,7 +22,7 @@ class Settings(BaseSettings):
     docs_url: str = "/docs"
     redoc_url: str = "/redoc"
     # JWT settings
-    secret_key: str = "super-secret"
+    jwt_secret_key: str = "super-secret"
     jwt_algorithm: str = "HS256"
     jwt_access_expires: int = 3600 * 24 * 7
     jwt_refresh_expires: int = 3600 * 24 * 30


### PR DESCRIPTION
매번 다른 리포를 생성할 때마다 `secret_key`를 `jwt_secret_key`로 수정하는 작업이 반복되어서 해당 부분을 수정했습니다.
추가적으로 다른 레거시한 부분도 확인이 되어 수정 작업을 진행했습니다. 
- API의 secret_key, access_expires, refresh_expires, algorithm
- is_refresh 호출시 누락된 인자 추가